### PR TITLE
型定義の調整

### DIFF
--- a/src/hooks/useCovidData.ts
+++ b/src/hooks/useCovidData.ts
@@ -1,48 +1,5 @@
 import { prisma } from "@/lib/prisma";
-
-/**
- * 都道府県データの型定義
- * id: 都道府県ID
- * name: 都道府県名
- */
-interface Prefecture {
-	id: number;
-	name: string;
-}
-
-/**
- * 系統（変異株）データの型定義
- * id: 系統ID
- * name: 系統名（変異株名）
- */
-interface Lineage {
-	id: number;
-	name: string;
-}
-
-/**
- * COVID-19データと関連情報を含む型定義
- * id: データID
- * date: 日付
- * count: 検出数
- * ratio: 検出率（百分率）
- * prefectureId: 都道府県ID（外部キー）
- * lineageId: 系統ID（外部キー）
- * wave: 感染波の番号
- * prefecture: 都道府県の関連データ
- * lineage: 系統の関連データ
- */
-interface CovidDataWithRelations {
-	id: number;
-	date: Date;
-	count: number;
-	ratio: number;
-	prefectureId: number;
-	lineageId: number;
-	wave: number;
-	prefecture: Prefecture;
-	lineage: Lineage;
-}
+import { CovidDataWithRelations } from "@/types/dataType";
 
 /**
  * COVID-19データ操作のためのカスタムフック

--- a/src/types/dataType.ts
+++ b/src/types/dataType.ts
@@ -1,0 +1,43 @@
+/**
+ * 都道府県データの型定義
+ * id: 都道府県ID
+ * name: 都道府県名
+ */
+export interface Prefecture {
+	id: number;
+	name: string;
+}
+
+/**
+ * 系統（変異株）データの型定義
+ * id: 系統ID
+ * name: 系統名（変異株名）
+ */
+export interface Lineage {
+	id: number;
+	name: string;
+}
+
+/**
+ * COVID-19データと関連情報を含む型定義
+ * id: データID
+ * date: 日付
+ * count: 検出数
+ * ratio: 検出率（百分率）
+ * prefectureId: 都道府県ID（外部キー）
+ * lineageId: 系統ID（外部キー）
+ * wave: 感染波の番号
+ * prefecture: 都道府県の関連データ
+ * lineage: 系統の関連データ
+ */
+export interface CovidDataWithRelations {
+    id: number;
+    date: Date;
+    count: number;
+    ratio: number;
+    prefectureId: number;
+    lineageId: number;
+    wave: number;
+    prefecture: Prefecture;
+    lineage: Lineage;
+}


### PR DESCRIPTION
型定義をsrc/types/dataType.tsに移動し、useCovidData.tsから不要な型定義を削除しました。