### PR TITLE
10 database revison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 
 #data
 prisma/dev.db
+prisma/dev.db

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,7 @@
 
 # dependencies
 /node_modules
-<<<<<<< HEAD
 /nakano_src
-=======
->>>>>>> 1830ad50d286bcfa2c180a01d3eaa136656af8e5
 /.pnp
 .pnp.*
 .yarn/*
@@ -43,3 +40,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+#data
+prisma/dev.db

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model CovidData {
   lineage      Lineage    @relation(fields: [lineageId], references: [id])
   lineageId    Int
   wave         Int
+  rank         Int?
 
   @@index([date])
   @@index([prefectureId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,7 +36,7 @@ model CovidData {
   lineage      Lineage    @relation(fields: [lineageId], references: [id])
   lineageId    Int
   wave         Int
-  rank         Int
+  rank         Int?
 
   @@index([date])
   @@index([prefectureId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,7 +36,7 @@ model CovidData {
   lineage      Lineage    @relation(fields: [lineageId], references: [id])
   lineageId    Int
   wave         Int
-  rank         Int?
+  rank         Int
 
   @@index([date])
   @@index([prefectureId])

--- a/scripts/import-data.ts
+++ b/scripts/import-data.ts
@@ -148,7 +148,8 @@ async function importData() {
       // ファイル名から都道府県名を抽出
       for (const file of csvFiles) {
         // 「Rank_lineage_都道府県名_Nwave.csv」という命名規則からマッチング
-        const match = file.match(/Rank_lineage_([^_]+)_\d+wave\.csv/);
+        // 正規表現[/d-]は、数字(/d)またはハイフン(-)が1文字以上続く文字列を抽出
+        const match = file.match(/Rank_lineage_([^_]+)_[\d-]+wave\.csv/);
         if (match && match[1]) {
           const prefecture = match[1];
           // 特殊なファイル（all, easy, major）は都道府県ではないのでスキップ
@@ -200,7 +201,7 @@ async function importData() {
       for (const file of csvFiles) {
         // 都道府県名をファイル名から抽出
         // 6-8波がインポートされないのは、ここで、\dが1文字の数値で見ているからだと仮定
-        const match = file.match(/Rank_lineage_([^_]+)_\d+wave\.csv/);
+        const match = file.match(/Rank_lineage_([^_]+)_[\d-]+wave\.csv/);
         if (!match || !match[1]) continue;
         
         const prefecture = match[1];
@@ -307,7 +308,7 @@ async function importData() {
       const csvFiles = files.filter(file => file.endsWith('_Rank.csv'));
       for (const file of csvFiles) {
           // ファイル名から都道府県名を抽出 (例: Rank_lineage_Aichi_6wave_Rank.csv)
-          const match = file.match(/Rank_lineage_([^_]+)_\d+wave_Rank\.csv/);
+          const match = file.match(/Rank_lineage_([^_]+)_[\d-]+wave_Rank\.csv/);
           if (!match || !match[1]) continue;
 
           const prefectureName = match[1];

--- a/scripts/import-data.ts
+++ b/scripts/import-data.ts
@@ -347,12 +347,15 @@ async function importData() {
                   const dateKey = dateKeys[j - 1]?.trim();
                   const rankValueStr = values[j]?.trim();
 
-                  if (!dateKey || !rankValueStr) continue;
+                  if (!dateKey) continue;
 
                   const formattedDate = parseDate(dateKey);
-                  const rank = parseInt(rankValueStr, 10);
-
-                  if (isNaN(rank)) continue;
+                  // rankValueStrが空文字列、null、undefinedの場合は0を設定
+                  let rank = 0;
+                  if (rankValueStr && rankValueStr !== '') {
+                      const parsedRank = parseInt(rankValueStr, 10);
+                      rank = isNaN(parsedRank) ? 0 : parsedRank;
+                  }
                   try {
                       // 既存のデータレコードを特定し、rankフィールドを更新
                       await prisma.covidData.updateMany({


### PR DESCRIPTION
# 概要
データインポートスクリプト（scripts/import-data.ts）を修正しました。
主な変更点は、rank列のインポート機能の追加と、ratio列の計算ロジックの改善です。これにより、データの完全性が向上し、処理の安定性と効率が改善されます。

# 詳細
1. rank列のインポート機能追加
6wave_Rank、7wave_Rankなどの順位データ（*_Rank.csv）を読み込む処理を追加しました。

- covidDataテーブルに対して、都道府県ID、系統ID、日付、波番号の4つのキーが一致するレコードを特定し、rank値をupdateManyで更新します。

- 順位データが存在しない（nullまたは空文字）場合は、エラーを防ぐためにデフォルト値として 0 を設定するように修正しました。

2. ratio列の計算ロジック修正
- ratio（割合）を計算する際の分母となる「各日付の系統数合計」を、データ処理の最初に一括で計算するようロジックを改善しました。

- dateTotalsマップに日付ごとの合計値を保持することで、行ごとの処理で合計値を再計算する必要がなくなり、処理効率が向上します。

- また、合計値が0の場合のゼロ除算を確実に防止し、コードの安定性を高めました。

3. その他改善
- ファイル名から波番号を抽出する正規表現を修正し、6-8waveのようなハイフンを含むファイル名にも対応できるようにしました。 (`/Rank_lineage_([^_]+)_[\d-]+wave_Rank\.csv/`)

- 系統名がデータベースに存在しない場合、その場でlineageテーブルに新規登録する処理を、rankデータのインポート処理にも追加しました。

issue #10